### PR TITLE
Enable FIOPS IO scheduler by default

### DIFF
--- a/rootdir/etc/init.armani.rc
+++ b/rootdir/etc/init.armani.rc
@@ -394,8 +394,8 @@ on property:sys.boot_completed=1
     write /sys/devices/system/cpu/cpu3/online 1
 
 on property:init.svc.bootanim=stopped
-    # Switch to ROW and balanced mode after boot for better UX
-    write /sys/block/mmcblk0/queue/scheduler row
+    # Switch to FIOPS and balanced mode after boot for better UX
+    write /sys/block/mmcblk0/queue/scheduler fiops
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor ondemand
     write /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor ondemand
     write /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor ondemand


### PR DESCRIPTION
ROW is falling out of favor due to random EMMC stalls and
performance edge cases. FIOPS is lightweight and has a great
all-around performance profile.
