### PR TITLE
overlay: Enable proximity check on screen wake

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -248,6 +248,12 @@
     <!-- Is the device LTE capable -->
     <bool name="config_lte_capable">false</bool>
 
+    <!-- Default value for proximity check on screen wake
+         NOTE ! - Enable for devices that have a fast response proximity sensor (ideally < 300ms)
+    -->
+    <bool name="config_proximityCheckOnWake">true</bool>
+    <integer name="config_proximityCheckTimeout">250</integer>
+
     <!-- Defines the system property to set for performance profile xe: sys.cpu.modes. Leave it
          blank if the device do not support performance profiles -->
     <string name="config_perf_profile_prop" translatable="false">sys.perf.profile</string>


### PR DESCRIPTION
My phone enjoys taking pictures and making phone calls while
it is in my pocket. Enable proximity check on screen wake to
stop this annoying behaviour. This will cause delays when
pressing the power button to wake the screen, but it can be
disabled from settings.
